### PR TITLE
feat: hide entity delete button for stewards

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
       ATLAS_EXTERNAL_URL: 'http://localhost:8087/atlas/atlas'
       ELASTIC_CERTIFICATE_PATH: '/opt/flink/certs/ca/ca.crt'
       ELASTICSEARCH_CERTIFICATE_PATH: '/opt/flink/certs/ca/ca.crt'
-      UPLOAD_DATA: "false"
+      UPLOAD_DATA: "true"
       DATA_DICTIONARY_PATH: "/workspace/apps/m4i-data-dictionary-io/m4i_data_dictionary_io/example/Data Dictionary in IoT Terms.xlsm"
     command: 'taskmanager --cap-add=SYS_PTRACE --security-opt seccomp=unconfined'
     cap_add:

--- a/.devcontainer/postcreate.sh
+++ b/.devcontainer/postcreate.sh
@@ -27,7 +27,7 @@ done < "$JARS_DIR/manifest"
 upload_to_atlas () {
     echo "Uploading data to Apache Atlas..."
     pushd backend/m4i-atlas-post-install/bin
-    ./upload_sample_data.sh only_gov_quality.zip
+    ./upload_sample_data.sh
     popd
 }
 

--- a/apps/atlas/src/app/search/components/editor/editor.component.html
+++ b/apps/atlas/src/app/search/components/editor/editor.component.html
@@ -17,9 +17,9 @@
 </ng-container>
 <ng-container footer>
   <div *ngIf="currentTab === 'entity'" class="buttons" class="mt-6">
-    <!-- <div *models4insight-keycloak-role-permission="'ROLE_ADMIN'"
-    > -->
-      <ng-container *models4insight-keycloak-role-permission="'ROLE_ADMIN'" *ngIf="deleteAllowed$ | async">
+    <div *models4insight-keycloak-role-permission="'ROLE_ADMIN'"
+    >
+      <ng-container *ngIf="deleteAllowed$ | async">
           <a
             models4insight-holdable
             [holdTime]="3"
@@ -30,7 +30,7 @@
             Delete
           </a>
         </ng-container>
-    <!-- </div> -->
+    </div>
 
     <a
       class="button is-success"

--- a/apps/atlas/src/app/search/components/editor/editor.component.html
+++ b/apps/atlas/src/app/search/components/editor/editor.component.html
@@ -17,17 +17,21 @@
 </ng-container>
 <ng-container footer>
   <div *ngIf="currentTab === 'entity'" class="buttons" class="mt-6">
-    <ng-container *ngIf="deleteAllowed$ | async">
-      <a
-        models4insight-holdable
-        [holdTime]="3"
-        (held)="deleteEntity($event)"
-        class="button is-danger mr-3"
-        [class.is-loading]="isDeletingEntity$ | async"
-      >
-        Delete
-      </a>
-    </ng-container>
+    <!-- <div *models4insight-keycloak-role-permission="'ROLE_ADMIN'"
+    > -->
+      <ng-container *models4insight-keycloak-role-permission="'ROLE_ADMIN'" *ngIf="deleteAllowed$ | async">
+          <a
+            models4insight-holdable
+            [holdTime]="3"
+            (held)="deleteEntity($event)"
+            class="button is-danger mr-3"
+            [class.is-loading]="isDeletingEntity$ | async"
+          >
+            Delete
+          </a>
+        </ng-container>
+    <!-- </div> -->
+
     <a
       class="button is-success"
       [class.is-loading]="isUpdatingEntity$ | async"

--- a/apps/atlas/src/app/search/components/editor/editor.component.html
+++ b/apps/atlas/src/app/search/components/editor/editor.component.html
@@ -17,7 +17,7 @@
 </ng-container>
 <ng-container footer>
   <div *ngIf="currentTab === 'entity'" class="buttons" class="mt-6">
-    <div *models4insight-keycloak-role-permission="'ROLE_ADMIN'"
+    <ng-container *models4insight-keycloak-role-permission="'ROLE_ADMIN'"
     >
       <ng-container *ngIf="deleteAllowed$ | async">
           <a
@@ -30,7 +30,7 @@
             Delete
           </a>
         </ng-container>
-    </div>
+    </ng-container>
 
     <a
       class="button is-success"

--- a/apps/atlas/src/app/search/components/editor/editor.module.ts
+++ b/apps/atlas/src/app/search/components/editor/editor.module.ts
@@ -24,6 +24,7 @@ import { SystemEditorComponent } from './system/system-editor.component';
 import { TypeSelectModule } from './type-select/type-select.module';
 import { GovQualityDisplayComponent } from './components/gov-quality-display/gov-quality-display.component';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { KeycloakRolePermissionModule } from '@models4insight/permissions';
 
 @NgModule({
   imports: [
@@ -39,6 +40,7 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
     TypeSelectModule,
     GovernanceQualityCardModule,
     FontAwesomeModule,
+    KeycloakRolePermissionModule,
   ],
   declarations: [
     EditorComponent,


### PR DESCRIPTION
[2940 : Delete button visibility for stewards](https://dev.azure.com/AureliusEnterprise/Data%20Governance/_workitems/edit/2940/).

While editing entities, the delete button is only visible for users with permission ROLE-ADMIN.

Logged in as user Atlas (with roles "ROLE_ADMIN", "default-roles-atlas-dev" and "DATA_STEWARD"):

![Screenshot 2025-02-06 133021](https://github.com/user-attachments/assets/e0e6a589-7332-4ce5-a518-ede0c66c8a5e)

Logged in as steward_test_user (with role "DATA_STEWARD") - note that the login does not appear to work properly: 

![Screenshot 2025-02-06 131259](https://github.com/user-attachments/assets/fe988727-d820-4f46-952d-a99f0b64b05c)

Logged in as steward_test_user (with roles "DATA_STEWARD" and "default-roles-atlas-dev") - after adding the default role to the test user, the login works properly:

![Screenshot 2025-02-06 142400](https://github.com/user-attachments/assets/1054db61-4eee-4d66-bbe1-e68d7bce07e6)

