### PR TITLE
feat: add liveness probe to kubernetes config

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -171,7 +171,7 @@ Deploy Aurelius Atlas
 3. Deploy the services
 
     ```bash
-    cd Aurelius-Atlas-helm-chart
+    cd aurelius/k8s
     helm dependency update
     helm install --generate-name -n <namespace>  -f values.yaml --wait --timeout 15m0s .
     ```

--- a/k8s/charts/kafka-connect/README.md
+++ b/k8s/charts/kafka-connect/README.md
@@ -166,7 +166,7 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `customEnv.CUSTOM_SCRIPT_PATH` | Path to external bash script to run inside the container | see [values.yaml](values.yaml) for details |
-| `livenessProbe` | Requirement of `livenessProbe` depends on the custom script to be run  | see [values.yaml](values.yaml) for details |
+| `livenessProbe` | Executes the `livenessprobe.sh` script at regular intervals to check if Kafka Connect tasks are running  | see [values.yaml](values.yaml) for details |
 
 ### Deployment Topology
 

--- a/k8s/charts/kafka-connect/templates/deployment.yaml
+++ b/k8s/charts/kafka-connect/templates/deployment.yaml
@@ -138,10 +138,10 @@ spec:
               /etc/confluent/docker/run &
               $CUSTOM_SCRIPT_PATH
               sleep infinity
-          {{- if .Values.livenessProbe }}
+        {{- end }}
+        {{- if .Values.livenessProbe }}
           livenessProbe:
 {{ toYaml .Values.livenessProbe | trim | indent 12 }}
-          {{- end }}
         {{- end }}
           {{- if .Values.volumeMounts }}
           volumeMounts:

--- a/k8s/charts/kafka-connect/values.yaml
+++ b/k8s/charts/kafka-connect/values.yaml
@@ -118,12 +118,13 @@ secrets:
 ## As an example such a similar script is added to "cp-helm-charts/examples/create-connectors.sh"
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
-  # httpGet:
-  #   path: /connectors
-  #   port: 8083
-  # initialDelaySeconds: 30
-  # periodSeconds: 5
-  # failureThreshold: 10
+  exec:
+    command:
+    - /bin/sh
+    - -c
+    - /tmp/aurelius/bin/livenessprobe.sh
+  initialDelaySeconds: 60
+  periodSeconds: 10
 
 volumeMounts:
   - name: v-elastic-certs

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -59,7 +59,7 @@ ingress:
 
 global:
   external_hostname: "aureliusdev.westeurope.cloudapp.azure.com"
-  version: v2.0.13
+  version: v2.0.14
 
 post_install:
   upload_data: "true"

--- a/k8s/values.yaml
+++ b/k8s/values.yaml
@@ -59,7 +59,7 @@ ingress:
 
 global:
   external_hostname: "aureliusdev.westeurope.cloudapp.azure.com"
-  version: 2.0.8
+  version: v2.0.13
 
 post_install:
   upload_data: "true"


### PR DESCRIPTION
Extension of #28 .

Use the liveness script within the k8s configuration to act as a Kubernetes liveness probe for the kafka-connect service.

Testing:
Deploying tag v2.0.15 on Azure and describing the kafka-connect pod shows the following output with "liveness" information:
```
kubectl describe pod chart-1739191060-kafka-connect-f8779ccbc-8dltw -n test-namespace
```

![Screenshot 2025-02-10 140147](https://github.com/user-attachments/assets/76994751-0072-496a-bbbe-8ccb323b9bfb)

By pausing one of the connectors manually using the Kafka UI, we can force the liveness check to fail. The output now shows a non-zero restart count for the pod and the log message that the connectors are not running:

![Screenshot 2025-02-10 140131](https://github.com/user-attachments/assets/35a5bdae-b976-49d1-bb45-2ed16c128dac)
 
![image](https://github.com/user-attachments/assets/af6bc689-b47c-448b-8bd3-aa1e79687ca1)

