### PR TITLE
fix: update link to documentation

### DIFF
--- a/libs/shell/src/lib/header/header.component.html
+++ b/libs/shell/src/lib/header/header.component.html
@@ -119,7 +119,7 @@
             <div *ngIf="!hideDocumentation">
               <a
                 class="button is-outlined is-dark is-hidden-touch"
-                href="https://docs.models4insight.com"
+                href="https://aureliusenterprise.github.io/aurelius-atlas-documentation/"
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -128,7 +128,7 @@
               </a>
               <a
                 class="button is-outlined is-dark is-fullwidth is-hidden-desktop"
-                href="https://docs.models4insight.com"
+                href="https://aureliusenterprise.github.io/aurelius-atlas-documentation/"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
[\#2945](https://dev.azure.com/AureliusEnterprise/Data%20Governance/_workitems/edit/2945)

Update the documentation button to link to the Aurelius Atlas documentation, instead of the old models4insight documentation.

![Screenshot 2025-02-13 144050](https://github.com/user-attachments/assets/6f038946-f92b-41b6-bdd7-751db8317b2d)
