### PR TITLE
Bf/fix filter named dataqualitytype

### DIFF
--- a/apps/atlas/src/app/search/details/components/governance-quality-cards/governance-quality-cards.component.ts
+++ b/apps/atlas/src/app/search/details/components/governance-quality-cards/governance-quality-cards.component.ts
@@ -46,6 +46,7 @@ const sortingOptions: string[] = [
   'name',
   'dataqualityruledimension',
   'compliant',
+  "dataqualitytype",
 ];
 
 @Component({

--- a/apps/atlas/src/app/search/details/gov-quality/compliant-cards/compliant-cards.component.ts
+++ b/apps/atlas/src/app/search/details/gov-quality/compliant-cards/compliant-cards.component.ts
@@ -106,7 +106,7 @@ export class CompliantCardsSearchService extends EntityDetailsCardsSearchService
   }
 }
 
-const sortingOptions: string[] = ['name', 'dataqualitytype'];
+const sortingOptions: string[] = ['name'];
 
 @Component({
   selector: 'models4insight-compliant-cards',

--- a/apps/atlas/src/app/search/details/gov-quality/non-compliant-cards/non-compliant-cards.component.ts
+++ b/apps/atlas/src/app/search/details/gov-quality/non-compliant-cards/non-compliant-cards.component.ts
@@ -106,7 +106,7 @@ export class NonCompliantCardsSearchService extends EntityDetailsCardsSearchServ
   }
 }
 
-const sortingOptions: string[] = ['name', 'dataqualitytype'];
+const sortingOptions: string[] = ['name'];
 
 @Component({
   selector: 'models4insight-non-compliant-cards',

--- a/apps/atlas/src/app/search/search.component.ts
+++ b/apps/atlas/src/app/search/search.component.ts
@@ -32,8 +32,6 @@ export class SearchComponent implements OnInit {
   readonly faPlus = faPlus;
   readonly searchBarContext = searchBarContext;
 
-  private isQuerySubmitted = false; // Flag to track if the route change is due to onQuerySubmitted
-
   readonly query$: Observable<string>;
 
   constructor(
@@ -46,16 +44,14 @@ export class SearchComponent implements OnInit {
   ngOnInit() {
     this.router.events
       .pipe(filter((event) => event instanceof NavigationEnd))
-      .subscribe(() => {
-        if (!this.isQuerySubmitted) {
-          this.searchInput.clearQuery();
+      .subscribe((event: NavigationEnd) => {
+        if (event.urlAfterRedirects.includes('/search/browse')) {
+          this.searchInput.query = null;
         }
-        this.isQuerySubmitted = false; // Reset the flag after handling the route change
       });
   }
 
   onQuerySubmitted(query: string) {
-    this.isQuerySubmitted = true; // Set the flag to true before navigating
     this.searchService.filters = {};
     this.router.navigate(['/search/results'], {
       queryParams: { query },

--- a/apps/atlas/src/environments/environment.ts
+++ b/apps/atlas/src/environments/environment.ts
@@ -6,7 +6,7 @@ export const environment = {
   name: 'm4i_atlas',
   googleAnalyticsMeasurementID: 'UA-138345924-1',
   atlas: {
-    appSearchToken: 'search-8ra7geka99orzh45s3wm167b',
+    appSearchToken: 'search-7vsfwumomq3m6j6dt1vjeqbm',
   },
   i18n: {
     defaultLanguage: 'en-US',

--- a/apps/atlas/src/translations/en-US.json
+++ b/apps/atlas/src/translations/en-US.json
@@ -90,6 +90,7 @@
   "typename": "Type Name",
   "datadomainname": "Data Domain",
   "dataqualityruledimension": "Dimension",
+  "dataqualitytype": "Rule Type",
   "dqscore": "Quality Score",
   "dqscore_accuracy": "Accuracy",
   "dqscore_completeness": "Completeness",


### PR DESCRIPTION
1. Fix dataqualitytype filter issue.
This filter was set-up for gov-rule details in compliant and non-compliant card, but it is gov-rule attribute which in atlas named "Rule Type" (name of attribute is different in elastic, because of flink transformation). Filter is removed, and added for gov-rules card and attribute was renamed.

2. Clean query for search/browser (home) page