### PR TITLE
entity edit error

### DIFF
--- a/apps/atlas/src/app/search/services/entity-update/entity-update.service.ts
+++ b/apps/atlas/src/app/search/services/entity-update/entity-update.service.ts
@@ -74,10 +74,11 @@ export class EntityUpdateService extends BasicStore<EntityUpdateStoreContext> {
         ['entityDetails', 'entity', 'classifications'],
         { includeFalsy: true }
       )
-    const notPropogatedCurrentClassifications = currentClassifications.filter(
+    // filter out classifications that are not owned by the entity (being propagated from a relationship)
+    // thouse types of classifications are not editable
+    const ownedCurrentClassifications = currentClassifications.filter(
       (classification: Classification) => classification.entityGuid === guid
     );
-
 
     function difference(
       a: Classification[],
@@ -86,12 +87,12 @@ export class EntityUpdateService extends BasicStore<EntityUpdateStoreContext> {
       return a.filter((aa) => !b.find((bb) => aa.typeName === bb.typeName));
     }
 
-    const classificationsToAdd = notPropogatedCurrentClassifications
-      ? difference(classifications, notPropogatedCurrentClassifications)
+    const classificationsToAdd = ownedCurrentClassifications
+      ? difference(classifications, ownedCurrentClassifications)
       : classifications;
 
-    const classificationsToRemove = notPropogatedCurrentClassifications
-      ? difference(notPropogatedCurrentClassifications, classifications)
+    const classificationsToRemove = ownedCurrentClassifications
+      ? difference(ownedCurrentClassifications, classifications)
       : [];
 
     // When creating a new entity, any classifications direclty assigned to this entity will have a placeholder entityGuid.

--- a/apps/atlas/src/app/search/services/entity-update/entity-update.service.ts
+++ b/apps/atlas/src/app/search/services/entity-update/entity-update.service.ts
@@ -13,7 +13,6 @@ import { untilDestroyed } from '@models4insight/utils';
 import { Subject } from 'rxjs';
 import { exhaustMap } from 'rxjs/operators';
 import { EntityDetailsService } from '../entity-details/entity-details.service';
-// import { ClassificationService } from '../../components/classification/classification.service';
 
 export interface EntityUpdateStoreContext {
   readonly isUpdatingEntity?: boolean;
@@ -25,7 +24,6 @@ export class EntityUpdateService extends BasicStore<EntityUpdateStoreContext> {
   private readonly update$ = new Subject<AtlasEntityWithEXTInformation>();
 
   constructor(
-    // private readonly classificationService: ClassificationService,
     private readonly entityDetailsService: EntityDetailsService,
     private readonly entityApiService: EntityAPIService
   ) {
@@ -95,7 +93,7 @@ export class EntityUpdateService extends BasicStore<EntityUpdateStoreContext> {
     const classificationsToRemove = notPropogatedCurrentClassifications
       ? difference(notPropogatedCurrentClassifications, classifications)
       : [];
-    
+
     // When creating a new entity, any classifications direclty assigned to this entity will have a placeholder entityGuid.
     // Override the placeholder entityGuid with the given guid
     const classificationsWithoutPlaceholderGuid = classificationsToAdd.map(


### PR DESCRIPTION
Resolve an error when entity with propagated classification is being updated. It tries to delete them, what should not happened (it is also not possible).