### PR TITLE
feat: add accordion component

### DIFF
--- a/libs/components/src/lib/accordion/accordion.component.ts
+++ b/libs/components/src/lib/accordion/accordion.component.ts
@@ -1,0 +1,45 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
+
+/**
+ * Accordion component that can be expanded or collapsed.
+ */
+@Component({
+    selector: 'models4insight-accordion',
+    templateUrl: 'accordion.component.html',
+    styleUrls: ['accordion.component.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class AccordionComponent {
+    /**
+     * Whether the accordion is collapsed or not.
+     */
+    @Input() collapsed = true;
+
+    /**
+     * The FontAwesome icons used in the accordion.
+     */
+    protected readonly faChevronDown = faChevronDown;
+    protected readonly faChevronUp = faChevronUp;
+
+    /**
+     * Set the accordion to a collapsed state.
+     */
+    collapse() {
+        this.collapsed = true;
+    }
+
+    /**
+     * Set the accordion to an expanaded state.
+     */
+    expand() {
+        this.collapsed = false;
+    }
+
+    /**
+     * Toggle the accordion state. If it is expanded, it will collapse; if it is collapsed, it will expand.
+     */
+    toggle() {
+        this.collapsed = !this.collapsed;
+    }
+}

--- a/libs/components/src/lib/accordion/accordion.component.ts
+++ b/libs/components/src/lib/accordion/accordion.component.ts
@@ -12,9 +12,9 @@ import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 })
 export class AccordionComponent {
     /**
-     * Whether the accordion is collapsed or not.
+     * Whether the accordion is expanded or not.
      */
-    @Input() collapsed = true;
+    @Input() expanded = false;
 
     /**
      * The FontAwesome icons used in the accordion.
@@ -26,20 +26,20 @@ export class AccordionComponent {
      * Set the accordion to a collapsed state.
      */
     collapse() {
-        this.collapsed = true;
+        this.expanded = false;
     }
 
     /**
      * Set the accordion to an expanaded state.
      */
     expand() {
-        this.collapsed = false;
+        this.expanded = true;
     }
 
     /**
      * Toggle the accordion state. If it is expanded, it will collapse; if it is collapsed, it will expand.
      */
     toggle() {
-        this.collapsed = !this.collapsed;
+        this.expanded = !this.expanded;
     }
 }

--- a/libs/components/src/lib/accordion/accordion.module.ts
+++ b/libs/components/src/lib/accordion/accordion.module.ts
@@ -1,0 +1,11 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+import { AccordionComponent } from './accordion.component';
+
+@NgModule({
+    imports: [CommonModule, FontAwesomeModule],
+    declarations: [AccordionComponent],
+    exports: [AccordionComponent],
+})
+export class AccordionModule { }

--- a/libs/components/src/lib/accordion/acordion.component.html
+++ b/libs/components/src/lib/accordion/acordion.component.html
@@ -9,11 +9,11 @@
       (click)="toggle()"
     >
       <span class="icon has-text-primary">
-        <fa-icon [icon]="collapsed ? faChevronDown : faChevronUp"></fa-icon>
+        <fa-icon [icon]="expanded ? faChevronUp : faChevronDown"></fa-icon>
       </span>
     </button>
   </header>
-  <div *ngIf="!collapsed" class="card-content">
+  <div *ngIf="expanded" class="card-content">
     <ng-content select="[content]"></ng-content>
   </div>
 </div>

--- a/libs/components/src/lib/accordion/acordion.component.html
+++ b/libs/components/src/lib/accordion/acordion.component.html
@@ -1,0 +1,19 @@
+<div class="card">
+  <header class="card-header">
+    <div class="card-header-title">
+      <ng-content select="[header]"></ng-content>
+    </div>
+    <button
+      class="card-header-icon"
+      aria-label="Toggle content"
+      (click)="toggle()"
+    >
+      <span class="icon has-text-primary">
+        <fa-icon [icon]="collapsed ? faChevronDown : faChevronUp"></fa-icon>
+      </span>
+    </button>
+  </header>
+  <div *ngIf="!collapsed" class="card-content">
+    <ng-content select="[content]"></ng-content>
+  </div>
+</div>


### PR DESCRIPTION
This PR introduces the `models4insight-accordion` component, which enables collapsible sections on a page.

## Usage

```html
<models4insight-accordion [expanded]="false">
    <ng-container header>
        <p>Accordion Header</p>
    </ng-container>
    <ng-container content>
        <p>Accordion Content</p>
    </ng-container>
</models4insight-accordion>
```

## Features

- Header slot: Always visible; used for the accordion title.
- Content slot: Rendered only when the accordion is expanded.
- Toggle button: Expand or collapse the content.
- [expanded] input: Optional boolean to control the initial state (default: false).

<img width="887" height="333" alt="image" src="https://github.com/user-attachments/assets/2aaaee2e-8bb1-460d-bf94-5073dc3d85f1" />