### PR TITLE
fix: change field type to data type in properties table

### DIFF
--- a/apps/atlas/src/translations/en-US.json
+++ b/apps/atlas/src/translations/en-US.json
@@ -33,7 +33,7 @@
   "m4i_elastic": "Elastic",
   "qualifiedName": "Qualified Name",
   "attributeType": "Attribute Type",
-  "fieldType": "Field Type",
+  "fieldType": "Data Type",
   "dataDomain": "Data Domain",
   "systems": "Systems",
   "collections": "Collections",

--- a/libs/m4i-atlas-core/m4i_atlas_core/entities/atlas/data_dictionary/BusinessField.py
+++ b/libs/m4i-atlas-core/m4i_atlas_core/entities/atlas/data_dictionary/BusinessField.py
@@ -25,7 +25,7 @@ data_field_attributes_def = [
         name="fieldType",
         type_name="string",
         description="The classification of the data type of the field",
-        display_name="Field Type"
+        display_name="Data Type"
     ),
     AttributeDef(
         name="hasContent",


### PR DESCRIPTION
Ticket: https://dev.azure.com/AureliusEnterprise/Data%20Governance/_workitems/edit/2969
- changed the display from field type to Data type
<img width="1717" height="306" alt="Screenshot 2025-08-12 132630" src="https://github.com/user-attachments/assets/1b83bf45-d003-4efc-9f41-ce5665315e02" />
