### PR TITLE
fix: missing properties collapse and clickable functionality for people

### DIFF
--- a/apps/atlas/src/app/search/components/people/people.component.html
+++ b/apps/atlas/src/app/search/components/people/people.component.html
@@ -3,64 +3,53 @@
     No people assigned.
   </p>
 </ng-container>
-
 <ng-container *ngIf="details$ | async as details" class="container">
   <ng-container
-    *ngIf="
-      deduplicate(details.entity.relationshipAttributes?.domainLead) as domain"
+  *ngIf="deduplicate(details.entity.relationshipAttributes?.domainLead) as domainLeads"
   >
-    <div *ngIf="domain.length > 0">
-      <span class="pointer" (click)="directToDetailsPage(domain.guid)">
-        <span class="icon is-small">
-          <fa-icon class="business" [icon]="personsIcon"> </fa-icon>
-        </span>
-        <span> Domain Lead(s): </span>
-        <ng-container
-          *ngFor="let domain of domain; let last = last"
-          class="pointer"
-          (click)="directToDetailsPage(domain.guid)"
-        >
-          <a>{{ domain.displayText }}</a><span *ngIf="!last">, </span>
-        </ng-container>
+    <div *ngIf="domainLeads.length > 0">
+      <span class="icon is-small">
+        <fa-icon class="business" [icon]="personsIcon"> </fa-icon>
       </span>
+      <span> Domain Lead(s): </span>
+      <ng-container *ngFor="let domainLead of domainLeads; let last = last">
+        <span class="pointer" (click)="directToDetailsPage(domainLead.guid)">
+          <a>{{ domainLead.displayText }}</a>
+        </span>
+        <span *ngIf="!last">, </span>
+      </ng-container>
     </div>
   </ng-container>
   <ng-container
-    *ngIf="deduplicate(details.entity.relationshipAttributes?.businessOwner) as owners"
+  *ngIf="deduplicate(details.entity.relationshipAttributes?.businessOwner) as owners"
   >
     <div *ngIf="owners.length > 0">
-      <span class="pointer" (click)="directToDetailsPage(domain.guid)">
-        <span class="icon is-small">
-          <fa-icon class="business" [icon]="personsIcon"> </fa-icon>
-        </span>
-        <span> Data Owner(s): </span>
-        <ng-container
-          *ngFor="let owner of owners; let last = last"
-          class="pointer"
-          (click)="directToDetailsPage(owner.guid)"
-        >
-          <a>{{ owner.displayText }}</a><span *ngIf="!last">, </span>
-        </ng-container>
+      <span class="icon is-small">
+        <fa-icon class="business" [icon]="personsIcon"> </fa-icon>
       </span>
+      <span> Data Owner(s): </span>
+      <ng-container *ngFor="let owner of owners; let last = last">
+        <span class="pointer" (click)="directToDetailsPage(owner.guid)">
+          <a>{{ owner.displayText }}</a>
+        </span>
+        <span *ngIf="!last">, </span>
+      </ng-container>
     </div>
   </ng-container>
-    <ng-container
-    *ngIf="deduplicate(details.entity.relationshipAttributes?.steward) as stewards"
+  <ng-container
+  *ngIf="deduplicate(details.entity.relationshipAttributes?.steward) as stewards"
   >
     <div *ngIf="stewards.length > 0">
-      <span class="pointer" (click)="directToDetailsPage(domain.guid)">
-        <span class="icon is-small">
-          <fa-icon class="business" [icon]="personsIcon"> </fa-icon>
-        </span>
-        <span> Data Steward(s): </span>
-        <ng-container
-          *ngFor="let steward of stewards; let last = last"
-          class="pointer"
-          (click)="directToDetailsPage(steward.guid)"
-        >
-          <a>{{ steward.displayText }}</a><span *ngIf="!last">, </span>
-        </ng-container>
+      <span class="icon is-small">
+        <fa-icon class="business" [icon]="personsIcon"> </fa-icon>
       </span>
+      <span> Data Steward(s): </span>
+      <ng-container *ngFor="let steward of stewards; let last = last">
+        <span class="pointer" (click)="directToDetailsPage(steward.guid)">
+          <a>{{ steward.displayText }}</a>
+        </span>
+        <span *ngIf="!last">, </span>
+      </ng-container>
     </div>
   </ng-container>
 </ng-container>

--- a/apps/atlas/src/app/search/components/people/people.component.ts
+++ b/apps/atlas/src/app/search/components/people/people.component.ts
@@ -40,7 +40,9 @@ export class PeopleComponent implements OnInit {
         })
       );
   }
-
+  directToDetailsPage(guid: string) {
+    this.router.navigate(['search/details', guid]);
+  }
   deduplicate(items: any[] = []): any[] {
 
     // Build a map to keep the first instance of any given guid

--- a/apps/atlas/src/app/search/details/collection/collection-details.component.html
+++ b/apps/atlas/src/app/search/details/collection/collection-details.component.html
@@ -57,11 +57,15 @@
   <models4insight-governance-quality-cards></models4insight-governance-quality-cards>
 </div>
 
-<div id="properties-details" class="box">
-  <h3 class="title is-3">
-    Properties
-  </h3>
-  <models4insight-properties></models4insight-properties>
+<div id="properties-details">
+  <models4insight-accordion>
+    <ng-container header>
+      <h3 class="title is-3">Properties</h3>
+    </ng-container>
+    <ng-container content>
+      <models4insight-properties></models4insight-properties>
+    </ng-container>
+  </models4insight-accordion>
 </div>
 
 <models4insight-details-navigation>

--- a/apps/atlas/src/app/search/details/collection/collection-details.module.ts
+++ b/apps/atlas/src/app/search/details/collection/collection-details.module.ts
@@ -4,6 +4,7 @@ import { DataQualityListModule } from '../../components/data-quality-list/data-q
 import { DetailsCardsListModule } from '../components/details-cards-list/details-cards-list.module';
 import { DetailsNavigationModule } from '../components/navigation/details-navigation.module';
 import { PropertiesModule } from '../components/properties/properties.module';
+import { AccordionModule } from '@models4insight/components';
 import { CollectionDetailsComponent } from './collection-details.component';
 import { DatasetsCardsComponent } from './datasets-cards/datasets-cards.component';
 import { GovernanceQualityCardsModule } from '../components/governance-quality-cards/governance-quality-cards.module';
@@ -17,7 +18,8 @@ import { DescriptionModule } from '../../components/description/description.modu
     DetailsCardsListModule,
     DetailsNavigationModule,
     GovernanceQualityCardsModule,
-    PropertiesModule
+    PropertiesModule,
+    AccordionModule
   ],
   declarations: [DatasetsCardsComponent, CollectionDetailsComponent]
 })

--- a/apps/atlas/src/app/search/details/field/field-details.component.html
+++ b/apps/atlas/src/app/search/details/field/field-details.component.html
@@ -85,11 +85,15 @@
   <models4insight-governance-quality-cards></models4insight-governance-quality-cards>
 </div>
 
-<div id="properties-details" class="box">
-  <h3 class="title is-3">
-    Properties
-  </h3>
-  <models4insight-properties></models4insight-properties>
+<div id="properties-details">
+  <models4insight-accordion>
+    <ng-container header>
+      <h3 class="title is-3">Properties</h3>
+    </ng-container>
+    <ng-container content>
+      <models4insight-properties></models4insight-properties>
+    </ng-container>
+  </models4insight-accordion>
 </div>
 
 <models4insight-details-navigation>

--- a/apps/atlas/src/app/search/details/field/field-details.module.ts
+++ b/apps/atlas/src/app/search/details/field/field-details.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { DataQualityListModule } from '../../components/data-quality-list/data-quality-list.module';
+import { AccordionModule } from '@models4insight/components';
 import { DescriptionModule } from '../../components/description/description.module';
 import { DetailsCardsListModule } from '../components/details-cards-list/details-cards-list.module';
 import { GovernanceQualityCardsModule } from '../components/governance-quality-cards/governance-quality-cards.module';
@@ -19,7 +20,8 @@ import { FieldsCardsComponent } from './fields-cards/fields-cards.component';
     DetailsCardsListModule,
     DetailsNavigationModule,
     GovernanceQualityCardsModule,
-    PropertiesModule
+    PropertiesModule,
+    AccordionModule
   ],
   declarations: [
     AttributesCardsComponent,

--- a/apps/atlas/src/app/search/details/gov-quality/gov-quality-details.component.html
+++ b/apps/atlas/src/app/search/details/gov-quality/gov-quality-details.component.html
@@ -67,9 +67,15 @@
   <models4insight-compliant-cards></models4insight-compliant-cards>
 </div>
 
-<div id="properties-details" class="box">
-  <h3 class="title is-3">Properties</h3>
-  <models4insight-properties></models4insight-properties>
+<div id="properties-details">
+  <models4insight-accordion>
+    <ng-container header>
+      <h3 class="title is-3">Properties</h3>
+    </ng-container>
+    <ng-container content>
+      <models4insight-properties></models4insight-properties>
+    </ng-container>
+  </models4insight-accordion>
 </div>
 
 <models4insight-details-navigation>

--- a/apps/atlas/src/environments/environment.ts
+++ b/apps/atlas/src/environments/environment.ts
@@ -6,7 +6,7 @@ export const environment = {
   name: 'm4i_atlas',
   googleAnalyticsMeasurementID: 'UA-138345924-1',
   atlas: {
-    appSearchToken: 'search-1nkechup5uyxxh12565ervp2',
+    appSearchToken: 'search-6pp14sogy788iyqrb3bhbvon',
   },
   i18n: {
     defaultLanguage: 'en-US',


### PR DESCRIPTION
Pages where Properties table doesn't collapse:
- Data Field
- Governance Quality Rule: Gov. Quality
- Collection

People's names are now clickable: Owners, Stewards, Leads