### PR TITLE
fix: bitnami switched to public.ecr.aws docker image registry

### DIFF
--- a/k8s/charts/kafka-ui/values.yaml
+++ b/k8s/charts/kafka-ui/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 enabled: true
 
 image:
-  registry: docker.io
+  registry: public.ecr.aws
   repository: provectuslabs/kafka-ui
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.

--- a/k8s/charts/kafka/values.yaml
+++ b/k8s/charts/kafka/values.yaml
@@ -66,7 +66,7 @@ diagnosticMode:
 ## @param image.debug Specify if debug values should be set
 ##
 image:
-  registry: docker.io
+  registry: public.ecr.aws
   repository: bitnami/kafka
   tag: 3.2.1-debian-11-r0
   ## Specify a imagePullPolicy

--- a/k8s/charts/zookeeper/values.yaml
+++ b/k8s/charts/zookeeper/values.yaml
@@ -73,7 +73,7 @@ diagnosticMode:
 ## @param image.debug Specify if debug values should be set
 ##
 image:
-  registry: docker.io
+  registry: public.ecr.aws
   repository: bitnami/zookeeper
   tag: 3.8.0-debian-11-r23
   ## Specify a imagePullPolicy


### PR DESCRIPTION
Bitnami closed docker.io repos for kafka. 
Switched to public.ecr.aws registry