### PR TITLE
fix: api issue proxy

### DIFF
--- a/k8s/charts/reverse-proxy/conf.d/search-api.yaml
+++ b/k8s/charts/reverse-proxy/conf.d/search-api.yaml
@@ -1,14 +1,14 @@
 <Location /{{ .Release.Namespace }}/atlas/elastic>
-ProxyPass "http://{{ tpl .Values.search_api.serviceName . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.search_api.port }}/{{ .Values.search_api.engines.atlas }}/search.json"
-ProxyPassReverse "http://{{ tpl .Values.search_api.serviceName . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.search_api.port }}/{{ .Values.search_api.engines.atlas }}/search.json"
+ProxyPass "http://{{ tpl .Values.search_api.serviceName . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.search_api.port }}/api/as/v1/engines/{{ .Values.search_api.engines.atlas }}/search.json"
+ProxyPassReverse "http://{{ tpl .Values.search_api.serviceName . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.search_api.port }}/api/as/v1/engines/{{ .Values.search_api.engines.atlas }}/search.json"
 </Location>
 
 <Location /{{ .Release.Namespace }}/atlas/data_quality>
-ProxyPass "http://{{ tpl .Values.search_api.serviceName . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.search_api.port }}/{{ .Values.search_api.engines.dataQuality }}/search.json"
-ProxyPassReverse "http://{{ tpl .Values.search_api.serviceName . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.search_api.port }}/{{ .Values.search_api.engines.dataQuality }}/search.json"
+ProxyPass "http://{{ tpl .Values.search_api.serviceName . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.search_api.port }}/api/as/v1/engines/{{ .Values.search_api.engines.dataQuality }}/search.json"
+ProxyPassReverse "http://{{ tpl .Values.search_api.serviceName . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.search_api.port }}/api/as/v1/engines/{{ .Values.search_api.engines.dataQuality }}/search.json"
 </Location>
 
 <Location /{{ .Release.Namespace }}/atlas/gov_quality>
-ProxyPass "http://{{ tpl .Values.search_api.serviceName . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.search_api.port }}/{{ .Values.search_api.engines.govQuality }}/search.json"
-ProxyPassReverse "http://{{ tpl .Values.search_api.serviceName . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.search_api.port }}/{{ .Values.search_api.engines.govQuality }}/search.json"
+ProxyPass "http://{{ tpl .Values.search_api.serviceName . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.search_api.port }}/api/as/v1/engines/{{ .Values.search_api.engines.govQuality }}/search.json"
+ProxyPassReverse "http://{{ tpl .Values.search_api.serviceName . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.search_api.port }}/api/as/v1/engines/{{ .Values.search_api.engines.govQuality }}/search.json"
 </Location>

--- a/k8s/charts/search-api/values.yaml
+++ b/k8s/charts/search-api/values.yaml
@@ -10,7 +10,7 @@ service:
     internalPort: 6970
 
 appSearch:
-    baseUrl: https://enterprise-search-ent-http.{{ .Release.Namespace }}.svc.cluster.local:3002
+    baseUrl: https://enterprise-search-ent-http.{{ .Release.Namespace }}.svc:3002
     timeoutSeconds: 15
     engines:
         atlas: atlas-dev
@@ -21,7 +21,7 @@ elastic:
     username: elastic
     passwordSecret: elastic-search-es-elastic-user
     passwordKey: elastic
-    caCertSecretName: elastic-search-es-http-certs-public
+    caCertSecretName: enterprise-search-ent-http-certs-public
     caCertMountPath: /app/certs
     caCertPath: /app/certs/ca.crt
 


### PR DESCRIPTION
CA cert thing (`k8s/charts/search-api/values.yaml`)
First error was an SSL "self-signed certificate in certificate chain" error when search-api tried to talk to Enterprise Search. I dug around and it looks like `caCertSecretName` was pointed at `elastic-search-es-http-certs-public` (that's the Elasticsearch cert), but it should probably be `enterprise-search-ent-http-certs-public` (the Enterprise Search one)? I compared the two certs with openssl and they're definitely different, so I think this was just pointing at the wrong secret. Changed it and the error changed 

Hostname mismatch (`k8s/charts/search-api/values.yaml`)
After SSL error, got a new error: "Hostname mismatch, certificate is not valid for ...svc.cluster.local". Checked the actual cert and it only lists SANs up to `.svc`, not `.svc.cluster.local`. 

reverse-proxy sending the wrong path (`k8s/charts/reverse-proxy/conf.d/search-api.yaml`)
Once TLS was working, I started getting 403 "disallowed route" errors from search-api itself. Turned out reverse-proxy was forwarding requests to `/<engine>/search.json`, but search-api only allows `/api/as/v1/engines/<engine>/search.json` (checked the regex in proxy.py). Added the missing `/api/as/v1/engines/` prefix to the `ProxyPass` rules. 