### PR TITLE
fix: issues in the dutch translation

### DIFF
--- a/apps/atlas/src/app/search/components/people/people.component.html
+++ b/apps/atlas/src/app/search/components/people/people.component.html
@@ -7,7 +7,7 @@
             <span class="icon is-small">
                 <fa-icon class="business" [icon]="personsIcon"> </fa-icon>
             </span>
-            <span translate> search.components.people.domainLead </span>:
+            <span translate> search.components.people.domainLead </span>:&nbsp;
             <ng-container *ngFor="let domainLead of domainLeads; let last = last">
                 <span class="pointer" (click)="directToDetailsPage(domainLead.guid)">
                     <a>{{ domainLead.displayText }}</a>
@@ -21,7 +21,7 @@
             <span class="icon is-small">
                 <fa-icon class="business" [icon]="personsIcon"> </fa-icon>
             </span>
-            <span translate> search.components.people.dataOwner </span>:
+            <span translate> search.components.people.dataOwner </span>:&nbsp;
             <ng-container *ngFor="let owner of owners; let last = last">
                 <span class="pointer" (click)="directToDetailsPage(owner.guid)">
                     <a>{{ owner.displayText }}</a>
@@ -35,7 +35,7 @@
             <span class="icon is-small">
                 <fa-icon class="business" [icon]="personsIcon"> </fa-icon>
             </span>
-            <span translate> search.components.people.dataSteward </span>:
+            <span translate> search.components.people.dataSteward </span>:&nbsp;
             <ng-container *ngFor="let steward of stewards; let last = last">
                 <span class="pointer" (click)="directToDetailsPage(steward.guid)">
                     <a>{{ steward.displayText }}</a>

--- a/apps/atlas/src/app/search/components/people/people.component.html
+++ b/apps/atlas/src/app/search/components/people/people.component.html
@@ -7,7 +7,7 @@
             <span class="icon is-small">
                 <fa-icon class="business" [icon]="personsIcon"> </fa-icon>
             </span>
-            <span translate> search.components.people.domainLead </span>
+            <span translate> search.components.people.domainLead </span>:
             <ng-container *ngFor="let domainLead of domainLeads; let last = last">
                 <span class="pointer" (click)="directToDetailsPage(domainLead.guid)">
                     <a>{{ domainLead.displayText }}</a>
@@ -21,7 +21,7 @@
             <span class="icon is-small">
                 <fa-icon class="business" [icon]="personsIcon"> </fa-icon>
             </span>
-            <span translate> search.components.people.dataOwner </span>
+            <span translate> search.components.people.dataOwner </span>:
             <ng-container *ngFor="let owner of owners; let last = last">
                 <span class="pointer" (click)="directToDetailsPage(owner.guid)">
                     <a>{{ owner.displayText }}</a>
@@ -35,7 +35,7 @@
             <span class="icon is-small">
                 <fa-icon class="business" [icon]="personsIcon"> </fa-icon>
             </span>
-            <span translate> search.components.people.dataSteward </span>
+            <span translate> search.components.people.dataSteward </span>:
             <ng-container *ngFor="let steward of stewards; let last = last">
                 <span class="pointer" (click)="directToDetailsPage(steward.guid)">
                     <a>{{ steward.displayText }}</a>

--- a/apps/atlas/src/app/search/details/components/properties/properties.component.ts
+++ b/apps/atlas/src/app/search/details/components/properties/properties.component.ts
@@ -11,8 +11,8 @@ import { DataForTable, PropertiesService } from './properties.service';
 })
 export class PropertiesComponent implements OnInit {
     readonly tableConfigProperties: SortableTableShellConfig<DataForTable> = {
-        name: { displayName: 'search.details.properties.name', isNarrow: true },
-        value: { displayName: 'search.details.properties.value', isNarrow: true },
+        name: { displayName: 'search.details.components.properties.key', isNarrow: true },
+        value: { displayName: 'search.details.components.properties.value', isNarrow: true },
     };
 
     dataForTable$: Observable<DataForTable[]>;

--- a/apps/atlas/src/app/search/details/dataset/entity-cards/entity-cards.component.html
+++ b/apps/atlas/src/app/search/details/dataset/entity-cards/entity-cards.component.html
@@ -1,5 +1,5 @@
 <models4insight-details-cards-list
-    title="{{ 'search.details.entity.datasetsCards.title' | translate }}"
+    title="{{ 'search.details.dataset.entityCards.title' | translate }}"
     [enableDescendantsControl]="false"
     [sortingOptions]="sortingOptions"
 >

--- a/apps/atlas/src/translations/en-US.json
+++ b/apps/atlas/src/translations/en-US.json
@@ -396,7 +396,7 @@
             "people": {
                 "dataOwner": "Data Owner(s)",
                 "dataSteward": "Data Steward(s)",
-                "domainLead": "Domain lead",
+                "domainLead": "Domain Lead(s)",
                 "empty": "No people assigned."
             },
             "sorting": {
@@ -522,7 +522,7 @@
                 },
                 "description": "Description",
                 "entitiesCards": {
-                    "title": "Data Entities"
+                    "title": "Child Entities"
                 },
                 "governanceQualityRules": "Governance Quality Rules",
                 "people": "People",

--- a/apps/atlas/src/translations/nl-NL.json
+++ b/apps/atlas/src/translations/nl-NL.json
@@ -448,12 +448,12 @@
                     "title": "Governance Kwaliteitsregels"
                 },
                 "lineageModel": {
-                    "loading": "Linemodel laden…",
+                    "loading": "Lineage Model laden…",
                     "modelExplorerDataGovernance": {
                         "noDataGovernanceDetails": "Geen data‑governancedetails beschikbaar"
                     },
-                    "noLineageModelAvailable": "Geen linemodel beschikbaar",
-                    "retrieve": "Linemodel ophalen"
+                    "noLineageModelAvailable": "Geen Lineage Model beschikbaar",
+                    "retrieve": "Lineage Model ophalen"
                 },
                 "navigation": {
                     "details": "Details"
@@ -484,7 +484,7 @@
                     "title": "Datavelden"
                 },
                 "governanceQualityRules": "Governance Kwaliteitsregels",
-                "lineageModel": "Line model",
+                "lineageModel": "Lineage Model",
                 "producers": "Producenten",
                 "producersCards": {
                     "title": "Producenten"
@@ -586,7 +586,7 @@
                     "title": "Invoer"
                 },
                 "inputs": "Invoer",
-                "lineageModel": "Linemodel",
+                "lineageModel": "Lineage Model",
                 "outputCards": {
                     "title": "Uitvoer"
                 },
@@ -607,7 +607,7 @@
                 "dataQualityRules": "Datakwaliteitsregels",
                 "description": "Beschrijving",
                 "governanceQualityRules": "Governance Kwaliteitsregels",
-                "lineageModel": "Linemodel",
+                "lineageModel": "Lineage Model",
                 "processes": "Processen",
                 "processesCards": {
                     "title": "Processen"

--- a/apps/atlas/src/translations/nl-NL.json
+++ b/apps/atlas/src/translations/nl-NL.json
@@ -396,7 +396,7 @@
             "people": {
                 "dataOwner": "Data Eigenaar(s)",
                 "dataSteward": "Data Steward(s)",
-                "domainLead": "Domein Verantwoordelijke",
+                "domainLead": "Domein Verantwoordelijke(n)",
                 "empty": "Geen personen toegewezen."
             },
             "sorting": {
@@ -522,7 +522,7 @@
                 },
                 "description": "Beschrijving",
                 "entitiesCards": {
-                    "title": "Data Entiteiten"
+                    "title": "Onderliggende Entiteiten"
                 },
                 "governanceQualityRules": "Governance Kwaliteitsregels",
                 "people": "Personen",


### PR DESCRIPTION
Fixed the following issues:
- the lineage model is called line model: It should be Lineage Model
- in the dataset overview, there is a section called Datasets, but it should be named Data Entities & Data Entiteiten  
- Under the Properties section, of all entities, the column names do not appear correctly, I see the variable names and not the actual ones which should be Key & Value 
- After the name of each assigned role the ":" is missing. in the screenshot for example it should be Domein Verantwoordelijke: