### PR TITLE
refactor: change default Atlas admin username from 'admin' to 'atlas'

### DIFF
--- a/backend/m4i-lineage-rest-api/m4i_lineage_rest_api/credentials.py
+++ b/backend/m4i-lineage-rest-api/m4i_lineage_rest_api/credentials.py
@@ -1,6 +1,6 @@
 import os
 
 credentials = {
-    "atlas.credentials.username": os.getenv('atlas_username', 'admin'),
-    "atlas.credentials.password": os.getenv('atlas_password', 'admin')
+    "atlas.credentials.username": os.getenv("atlas_username", "atlas"),
+    "atlas.credentials.password": os.getenv("atlas_password", "admin"),
 }

--- a/dev/apache-atlas/atlas-simple-authz-policy.json
+++ b/dev/apache-atlas/atlas-simple-authz-policy.json
@@ -1,279 +1,138 @@
 {
-  "roles": {
-    "ROLE_ADMIN": {
-      "adminPermissions": [
-        {
-          "privileges": [
-            ".*"
-          ]
-        }
-      ],
-      "typePermissions": [
-        {
-          "privileges": [
-            ".*"
-          ],
-          "typeCategories": [
-            ".*"
-          ],
-          "typeNames": [
-            ".*"
-          ]
-        }
-      ],
-      "entityPermissions": [
-        {
-          "privileges": [
-            ".*"
-          ],
-          "entityTypes": [
-            ".*"
-          ],
-          "entityIds": [
-            ".*"
-          ],
-          "entityClassifications": [
-            ".*"
-          ],
-          "labels": [
-            ".*"
-          ],
-          "businessMetadata": [
-            ".*"
-          ],
-          "attributes": [
-            ".*"
-          ],
-          "classifications": [
-            ".*"
-          ]
-        }
-      ],
-      "relationshipPermissions": [
-        {
-          "privileges": [
-            ".*"
-          ],
-          "relationshipTypes": [
-            ".*"
-          ],
-          "end1EntityType": [
-            ".*"
-          ],
-          "end1EntityId": [
-            ".*"
-          ],
-          "end1EntityClassification": [
-            ".*"
-          ],
-          "end2EntityType": [
-            ".*"
-          ],
-          "end2EntityId": [
-            ".*"
-          ],
-          "end2EntityClassification": [
-            ".*"
-          ]
-        }
-      ]
+    "groupRoles": {
+        "DATA_SCIENTIST": ["DATA_SCIENTIST"],
+        "DATA_STEWARD": ["DATA_STEWARD"],
+        "RANGER_TAG_SYNC": ["DATA_SCIENTIST"],
+        "ROLE_ADMIN": ["ROLE_ADMIN"],
+        "hadoop": ["DATA_STEWARD"]
     },
-    "KEYCLOAK_ADMIN": {
-      "adminPermissions": [
-        {
-          "privileges": [
-            ".*"
-          ]
+    "roles": {
+        "DATA_SCIENTIST": {
+            "entityPermissions": [
+                {
+                    "attributes": [".*"],
+                    "businessMetadata": [".*"],
+                    "entityClassifications": [".*"],
+                    "entityIds": [".*"],
+                    "entityTypes": [".*"],
+                    "labels": [".*"],
+                    "privileges": ["entity-read", "entity-read-classification"]
+                }
+            ]
+        },
+        "DATA_STEWARD": {
+            "entityPermissions": [
+                {
+                    "attributes": [".*"],
+                    "businessMetadata": [".*"],
+                    "classifications": [".*"],
+                    "entityClassifications": [".*"],
+                    "entityIds": [".*"],
+                    "entityTypes": [".*"],
+                    "labels": [".*"],
+                    "privileges": [
+                        "entity-read",
+                        "entity-create",
+                        "entity-update",
+                        "entity-read-classification",
+                        "entity-add-classification",
+                        "entity-update-classification",
+                        "entity-remove-classification"
+                    ]
+                }
+            ],
+            "relationshipPermissions": [
+                {
+                    "end1EntityClassification": [".*"],
+                    "end1EntityId": [".*"],
+                    "end1EntityType": [".*"],
+                    "end2EntityClassification": [".*"],
+                    "end2EntityId": [".*"],
+                    "end2EntityType": [".*"],
+                    "privileges": ["add-relationship", "update-relationship", "remove-relationship"],
+                    "relationshipTypes": [".*"]
+                }
+            ]
+        },
+        "KEYCLOAK_ADMIN": {
+            "adminPermissions": [
+                {
+                    "privileges": [".*"]
+                }
+            ],
+            "entityPermissions": [
+                {
+                    "attributes": [".*"],
+                    "businessMetadata": [".*"],
+                    "classifications": [".*"],
+                    "entityClassifications": [".*"],
+                    "entityIds": [".*"],
+                    "entityTypes": [".*"],
+                    "labels": [".*"],
+                    "privileges": [".*"]
+                }
+            ],
+            "relationshipPermissions": [
+                {
+                    "end1EntityClassification": [".*"],
+                    "end1EntityId": [".*"],
+                    "end1EntityType": [".*"],
+                    "end2EntityClassification": [".*"],
+                    "end2EntityId": [".*"],
+                    "end2EntityType": [".*"],
+                    "privileges": [".*"],
+                    "relationshipTypes": [".*"]
+                }
+            ],
+            "typePermissions": [
+                {
+                    "privileges": [".*"],
+                    "typeCategories": [".*"],
+                    "typeNames": [".*"]
+                }
+            ]
+        },
+        "ROLE_ADMIN": {
+            "adminPermissions": [
+                {
+                    "privileges": [".*"]
+                }
+            ],
+            "entityPermissions": [
+                {
+                    "attributes": [".*"],
+                    "businessMetadata": [".*"],
+                    "classifications": [".*"],
+                    "entityClassifications": [".*"],
+                    "entityIds": [".*"],
+                    "entityTypes": [".*"],
+                    "labels": [".*"],
+                    "privileges": [".*"]
+                }
+            ],
+            "relationshipPermissions": [
+                {
+                    "end1EntityClassification": [".*"],
+                    "end1EntityId": [".*"],
+                    "end1EntityType": [".*"],
+                    "end2EntityClassification": [".*"],
+                    "end2EntityId": [".*"],
+                    "end2EntityType": [".*"],
+                    "privileges": [".*"],
+                    "relationshipTypes": [".*"]
+                }
+            ],
+            "typePermissions": [
+                {
+                    "privileges": [".*"],
+                    "typeCategories": [".*"],
+                    "typeNames": [".*"]
+                }
+            ]
         }
-      ],
-      "typePermissions": [
-        {
-          "privileges": [
-            ".*"
-          ],
-          "typeCategories": [
-            ".*"
-          ],
-          "typeNames": [
-            ".*"
-          ]
-        }
-      ],
-      "entityPermissions": [
-        {
-          "privileges": [
-            ".*"
-          ],
-          "entityTypes": [
-            ".*"
-          ],
-          "entityIds": [
-            ".*"
-          ],
-          "entityClassifications": [
-            ".*"
-          ],
-          "labels": [
-            ".*"
-          ],
-          "businessMetadata": [
-            ".*"
-          ],
-          "attributes": [
-            ".*"
-          ],
-          "classifications": [
-            ".*"
-          ]
-        }
-      ],
-      "relationshipPermissions": [
-        {
-          "privileges": [
-            ".*"
-          ],
-          "relationshipTypes": [
-            ".*"
-          ],
-          "end1EntityType": [
-            ".*"
-          ],
-          "end1EntityId": [
-            ".*"
-          ],
-          "end1EntityClassification": [
-            ".*"
-          ],
-          "end2EntityType": [
-            ".*"
-          ],
-          "end2EntityId": [
-            ".*"
-          ],
-          "end2EntityClassification": [
-            ".*"
-          ]
-        }
-      ]
     },
-    "DATA_SCIENTIST": {
-      "entityPermissions": [
-        {
-          "privileges": [
-            "entity-read",
-            "entity-read-classification"
-          ],
-          "entityTypes": [
-            ".*"
-          ],
-          "entityIds": [
-            ".*"
-          ],
-          "entityClassifications": [
-            ".*"
-          ],
-          "labels": [
-            ".*"
-          ],
-          "businessMetadata": [
-            ".*"
-          ],
-          "attributes": [
-            ".*"
-          ]
-        }
-      ]
-    },
-    "DATA_STEWARD": {
-      "entityPermissions": [
-        {
-          "privileges": [
-            "entity-read",
-            "entity-create",
-            "entity-update",
-            "entity-read-classification",
-            "entity-add-classification",
-            "entity-update-classification",
-            "entity-remove-classification"
-          ],
-          "entityTypes": [
-            ".*"
-          ],
-          "entityIds": [
-            ".*"
-          ],
-          "entityClassifications": [
-            ".*"
-          ],
-          "labels": [
-            ".*"
-          ],
-          "businessMetadata": [
-            ".*"
-          ],
-          "attributes": [
-            ".*"
-          ],
-          "classifications": [
-            ".*"
-          ]
-        }
-      ],
-      "relationshipPermissions": [
-        {
-          "privileges": [
-            "add-relationship",
-            "update-relationship",
-            "remove-relationship"
-          ],
-          "relationshipTypes": [
-            ".*"
-          ],
-          "end1EntityType": [
-            ".*"
-          ],
-          "end1EntityId": [
-            ".*"
-          ],
-          "end1EntityClassification": [
-            ".*"
-          ],
-          "end2EntityType": [
-            ".*"
-          ],
-          "end2EntityId": [
-            ".*"
-          ],
-          "end2EntityClassification": [
-            ".*"
-          ]
-        }
-      ]
+    "userRoles": {
+        "atlas": ["ROLE_ADMIN"],
+        "rangertagsync": ["DATA_SCIENTIST"]
     }
-  },
-  "userRoles": {
-    "admin": [
-      "ROLE_ADMIN"
-    ],
-    "rangertagsync": [
-      "DATA_SCIENTIST"
-    ]
-  },
-  "groupRoles": {
-    "ROLE_ADMIN": [
-      "ROLE_ADMIN"
-    ],
-    "hadoop": [
-      "DATA_STEWARD"
-    ],
-    "DATA_STEWARD": [
-      "DATA_STEWARD"
-    ],
-    "DATA_SCIENTIST": [
-      "DATA_SCIENTIST"
-    ],
-    "RANGER_TAG_SYNC": [
-      "DATA_SCIENTIST"
-    ]
-  }
 }

--- a/k8s/charts/atlas/conf/atlas-simple-authz-policy.json
+++ b/k8s/charts/atlas/conf/atlas-simple-authz-policy.json
@@ -1,306 +1,153 @@
 {
-  "roles": {
-    "ROLE_ADMIN": {
-      "adminPermissions": [
-        {
-          "privileges": [
-            ".*"
-          ]
-        }
-      ],
-      "typePermissions": [
-        {
-          "privileges": [
-            ".*"
-          ],
-          "typeCategories": [
-            ".*"
-          ],
-          "typeNames": [
-            ".*"
-          ]
-        }
-      ],
-      "entityPermissions": [
-        {
-          "privileges": [
-            ".*"
-          ],
-          "entityTypes": [
-            ".*"
-          ],
-          "entityIds": [
-            ".*"
-          ],
-          "entityClassifications": [
-            ".*"
-          ],
-          "labels": [
-            ".*"
-          ],
-          "businessMetadata": [
-            ".*"
-          ],
-          "attributes": [
-            ".*"
-          ],
-          "classifications": [
-            ".*"
-          ]
-        }
-      ],
-      "relationshipPermissions": [
-        {
-          "privileges": [
-            ".*"
-          ],
-          "relationshipTypes": [
-            ".*"
-          ],
-          "end1EntityType": [
-            ".*"
-          ],
-          "end1EntityId": [
-            ".*"
-          ],
-          "end1EntityClassification": [
-            ".*"
-          ],
-          "end2EntityType": [
-            ".*"
-          ],
-          "end2EntityId": [
-            ".*"
-          ],
-          "end2EntityClassification": [
-            ".*"
-          ]
-        }
-      ]
+    "groupRoles": {
+        "DATA_SCIENTIST": ["DATA_SCIENTIST"],
+        "DATA_STEWARD": ["DATA_STEWARD"],
+        "RANGER_TAG_SYNC": ["DATA_SCIENTIST"],
+        "ROLE_ADMIN": ["ROLE_ADMIN"],
+        "hadoop": ["DATA_STEWARD"]
     },
-    "KEYCLOAK_ADMIN": {
-      "adminPermissions": [
-        {
-          "privileges": [
-            ".*"
-          ]
+    "roles": {
+        "DATA_SCIENTIST": {
+            "entityPermissions": [
+                {
+                    "attributes": [".*"],
+                    "businessMetadata": [".*"],
+                    "entityClassifications": [".*"],
+                    "entityIds": [".*"],
+                    "entityTypes": [".*"],
+                    "labels": [".*"],
+                    "privileges": ["entity-read", "entity-read-classification"]
+                }
+            ],
+            "typePermissions": [
+                {
+                    "privileges": [".*"],
+                    "typeCategories": [".*"],
+                    "typeNames": [".*"]
+                }
+            ]
+        },
+        "DATA_STEWARD": {
+            "entityPermissions": [
+                {
+                    "attributes": [".*"],
+                    "businessMetadata": [".*"],
+                    "classifications": [".*"],
+                    "entityClassifications": [".*"],
+                    "entityIds": [".*"],
+                    "entityTypes": [".*"],
+                    "labels": [".*"],
+                    "privileges": [
+                        "entity-read",
+                        "entity-create",
+                        "entity-update",
+                        "entity-read-classification",
+                        "entity-add-classification",
+                        "entity-update-classification",
+                        "entity-remove-classification",
+                        "entity-read-*"
+                    ]
+                }
+            ],
+            "relationshipPermissions": [
+                {
+                    "end1EntityClassification": [".*"],
+                    "end1EntityId": [".*"],
+                    "end1EntityType": [".*"],
+                    "end2EntityClassification": [".*"],
+                    "end2EntityId": [".*"],
+                    "end2EntityType": [".*"],
+                    "privileges": ["add-relationship", "update-relationship", "remove-relationship"],
+                    "relationshipTypes": [".*"]
+                }
+            ],
+            "typePermissions": [
+                {
+                    "privileges": [".*"],
+                    "typeCategories": [".*"],
+                    "typeNames": [".*"]
+                }
+            ]
+        },
+        "KEYCLOAK_ADMIN": {
+            "adminPermissions": [
+                {
+                    "privileges": [".*"]
+                }
+            ],
+            "entityPermissions": [
+                {
+                    "attributes": [".*"],
+                    "businessMetadata": [".*"],
+                    "classifications": [".*"],
+                    "entityClassifications": [".*"],
+                    "entityIds": [".*"],
+                    "entityTypes": [".*"],
+                    "labels": [".*"],
+                    "privileges": [".*"]
+                }
+            ],
+            "relationshipPermissions": [
+                {
+                    "end1EntityClassification": [".*"],
+                    "end1EntityId": [".*"],
+                    "end1EntityType": [".*"],
+                    "end2EntityClassification": [".*"],
+                    "end2EntityId": [".*"],
+                    "end2EntityType": [".*"],
+                    "privileges": [".*"],
+                    "relationshipTypes": [".*"]
+                }
+            ],
+            "typePermissions": [
+                {
+                    "privileges": [".*"],
+                    "typeCategories": [".*"],
+                    "typeNames": [".*"]
+                }
+            ]
+        },
+        "ROLE_ADMIN": {
+            "adminPermissions": [
+                {
+                    "privileges": [".*"]
+                }
+            ],
+            "entityPermissions": [
+                {
+                    "attributes": [".*"],
+                    "businessMetadata": [".*"],
+                    "classifications": [".*"],
+                    "entityClassifications": [".*"],
+                    "entityIds": [".*"],
+                    "entityTypes": [".*"],
+                    "labels": [".*"],
+                    "privileges": [".*"]
+                }
+            ],
+            "relationshipPermissions": [
+                {
+                    "end1EntityClassification": [".*"],
+                    "end1EntityId": [".*"],
+                    "end1EntityType": [".*"],
+                    "end2EntityClassification": [".*"],
+                    "end2EntityId": [".*"],
+                    "end2EntityType": [".*"],
+                    "privileges": [".*"],
+                    "relationshipTypes": [".*"]
+                }
+            ],
+            "typePermissions": [
+                {
+                    "privileges": [".*"],
+                    "typeCategories": [".*"],
+                    "typeNames": [".*"]
+                }
+            ]
         }
-      ],
-      "typePermissions": [
-        {
-          "privileges": [
-            ".*"
-          ],
-          "typeCategories": [
-            ".*"
-          ],
-          "typeNames": [
-            ".*"
-          ]
-        }
-      ],
-      "entityPermissions": [
-        {
-          "privileges": [
-            ".*"
-          ],
-          "entityTypes": [
-            ".*"
-          ],
-          "entityIds": [
-            ".*"
-          ],
-          "entityClassifications": [
-            ".*"
-          ],
-          "labels": [
-            ".*"
-          ],
-          "businessMetadata": [
-            ".*"
-          ],
-          "attributes": [
-            ".*"
-          ],
-          "classifications": [
-            ".*"
-          ]
-        }
-      ],
-      "relationshipPermissions": [
-        {
-          "privileges": [
-            ".*"
-          ],
-          "relationshipTypes": [
-            ".*"
-          ],
-          "end1EntityType": [
-            ".*"
-          ],
-          "end1EntityId": [
-            ".*"
-          ],
-          "end1EntityClassification": [
-            ".*"
-          ],
-          "end2EntityType": [
-            ".*"
-          ],
-          "end2EntityId": [
-            ".*"
-          ],
-          "end2EntityClassification": [
-            ".*"
-          ]
-        }
-      ]
     },
-    "DATA_SCIENTIST": {
-      "entityPermissions": [
-        {
-          "privileges": [
-            "entity-read",
-            "entity-read-classification"
-          ],
-          "entityTypes": [
-            ".*"
-          ],
-          "entityIds": [
-            ".*"
-          ],
-          "entityClassifications": [
-            ".*"
-          ],
-          "labels": [
-            ".*"
-          ],
-          "businessMetadata": [
-            ".*"
-          ],
-          "attributes": [
-            ".*"
-          ]
-        }
-      ],
-      "typePermissions": [
-        {
-          "privileges": [
-            ".*"
-          ],
-          "typeCategories": [
-            ".*"
-          ],
-          "typeNames": [
-            ".*"
-          ]
-        }
-      ]
-    },
-    "DATA_STEWARD": {
-      "entityPermissions": [
-        {
-          "privileges": [
-            "entity-read",
-            "entity-create",
-            "entity-update",
-            "entity-read-classification",
-            "entity-add-classification",
-            "entity-update-classification",
-            "entity-remove-classification",
-            "entity-read-*"
-          ],
-          "entityTypes": [
-            ".*"
-          ],
-          "entityIds": [
-            ".*"
-          ],
-          "entityClassifications": [
-            ".*"
-          ],
-          "labels": [
-            ".*"
-          ],
-          "businessMetadata": [
-            ".*"
-          ],
-          "attributes": [
-            ".*"
-          ],
-          "classifications": [
-            ".*"
-          ]
-        }
-      ],
-      "relationshipPermissions": [
-        {
-          "privileges": [
-            "add-relationship",
-            "update-relationship",
-            "remove-relationship"
-          ],
-          "relationshipTypes": [
-            ".*"
-          ],
-          "end1EntityType": [
-            ".*"
-          ],
-          "end1EntityId": [
-            ".*"
-          ],
-          "end1EntityClassification": [
-            ".*"
-          ],
-          "end2EntityType": [
-            ".*"
-          ],
-          "end2EntityId": [
-            ".*"
-          ],
-          "end2EntityClassification": [
-            ".*"
-          ]
-        }
-      ],
-      "typePermissions": [
-        {
-          "privileges": [
-            ".*"
-          ],
-          "typeCategories": [
-            ".*"
-          ],
-          "typeNames": [
-            ".*"
-          ]
-        }
-      ]
+    "userRoles": {
+        "atlas": ["ROLE_ADMIN"],
+        "rangertagsync": ["DATA_SCIENTIST"]
     }
-  },
-  "userRoles": {
-    "admin": [
-      "ROLE_ADMIN"
-    ],
-    "rangertagsync": [
-      "DATA_SCIENTIST"
-    ]
-  },
-  "groupRoles": {
-    "ROLE_ADMIN": [
-      "ROLE_ADMIN"
-    ],
-    "hadoop": [
-      "DATA_STEWARD"
-    ],
-    "DATA_STEWARD": [
-      "DATA_STEWARD"
-    ],
-    "DATA_SCIENTIST": [
-      "DATA_SCIENTIST"
-    ],
-    "RANGER_TAG_SYNC": [
-      "DATA_SCIENTIST"
-    ]
-  }
 }

--- a/k8s/charts/atlas/conf/users-credentials--properties.yaml
+++ b/k8s/charts/atlas/conf/users-credentials--properties.yaml
@@ -1,4 +1,3 @@
 #username=group::sha256-password
-admin=ADMIN::a4a88c0872bf652bb9ed803ece5fd6e82354838a9bf59ab4babb1dab322154e1
+atlas=ADMIN::a4a88c0872bf652bb9ed803ece5fd6e82354838a9bf59ab4babb1dab322154e1
 rangertagsync=RANGER_TAG_SYNC::0afe7a1968b07d4c3ff4ed8c2d809a32ffea706c66cd795ead9048e81cfaf034
-

--- a/k8s/charts/keycloak/templates/secret-user-admin.yaml
+++ b/k8s/charts/keycloak/templates/secret-user-admin.yaml
@@ -7,6 +7,6 @@ data:
   {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "keycloak-secret-user-admin") | default dict }}
   {{- $secretData := (get $secretObj "data") | default dict }}
   # set $keycloakPassword to existing secret data or generate a random one when not exists
-  username: {{ get $secretData "username" | default "admin" | b64enc }}
+  username: {{ get $secretData "username" | default "atlas" | b64enc }}
   {{- $secretPassword := (get $secretData "password") | default (randAlphaNum 16 | b64enc) }}
   password: {{ $secretPassword | quote }}


### PR DESCRIPTION
## Summary

This PR changes the default Atlas admin username from `admin` to `atlas` across all relevant configuration files and code references.

## Changes

### Configuration Files
- **k8s/charts/atlas/conf/users-credentials--properties.yaml**: Updated credential entry from `admin=ADMIN::...` to `atlas=ADMIN::...`
- **k8s/charts/atlas/conf/atlas-simple-authz-policy.json**: Changed userRoles mapping key from `"admin"` to `"atlas"`
- **dev/apache-atlas/atlas-simple-authz-policy.json**: Same change as above for dev environment

### Helm Templates
- **k8s/charts/keycloak/templates/secret-user-admin.yaml**: Updated default username value from `"admin"` to `"atlas"`

### Backend Code
- **backend/m4i-lineage-rest-api/m4i_lineage_rest_api/credentials.py**: Changed fallback default for `atlas_username` environment variable from `'admin'` to `'atlas'`

## Notes

- The password default remains unchanged (`'admin'`) - only the username is being changed
- Storybook test data with `"createdBy": "admin"` was intentionally left as-is since it's mock/example data for UI testing
- Keycloak realm JSON files referencing roles like `ROLE_ADMIN`, `m4i_admin` are role names, not usernames, and were not modified
- The `KEYCLOAK_ATLAS_ADMIN_USERNAME: 'atlas'` in `k8s/charts/atlas/values.yaml` was already set to `'atlas'`

## Verification

All changes have been verified against the main branch to ensure no hardcoded references remain.