### PR TITLE
fix(keycloak): prevent double base64 encoding on secret upgrade

### DIFF
--- a/k8s/charts/keycloak/templates/postgresql-secret.yaml
+++ b/k8s/charts/keycloak/templates/postgresql-secret.yaml
@@ -11,5 +11,9 @@ data:
   postgres-username: {{ .Values.postgresql.globalVariables.POSTGRES_USER | b64enc }}
   {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace (include "keycloak.fullname" . | printf "%s-postgresql-secret") ) | default dict }}
   {{- $secretData := (get $secretObj "data") | default dict }}
-  postgres-password: {{ (get $secretData "postgres-password") | default (randAlphaNum 16) | b64enc }}
+  {{- if hasKey $secretData "postgres-password" }}
+  postgres-password: {{ index $secretData "postgres-password" }}
+  {{- else }}
+  postgres-password: {{ randAlphaNum 16 | b64enc }}
+  {{- end }}
 {{- end }}

--- a/k8s/charts/keycloak/templates/secret-user-admin.yaml
+++ b/k8s/charts/keycloak/templates/secret-user-admin.yaml
@@ -7,6 +7,10 @@ data:
   {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "keycloak-secret-user-admin") | default dict }}
   {{- $secretData := (get $secretObj "data") | default dict }}
   # set $keycloakPassword to existing secret data or generate a random one when not exists
-  username: {{ get $secretData "username" | default "atlas" | b64enc }}
+  {{- if hasKey $secretData "username" }}
+  username: {{ index $secretData "username" }}
+  {{- else }}
+  username: {{ "atlas" | b64enc }}
+  {{- end }}
   {{- $secretPassword := (get $secretData "password") | default (randAlphaNum 16 | b64enc) }}
   password: {{ $secretPassword | quote }}

--- a/k8s/charts/keycloak/templates/secret-user-data.yaml
+++ b/k8s/charts/keycloak/templates/secret-user-data.yaml
@@ -7,6 +7,10 @@ data:
   {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "keycloak-secret-user-data") | default dict }}
   {{- $secretData := (get $secretObj "data") | default dict }}
   # set $keycloakPassword to existing secret data or generate a random one when not exists
-  username: {{ get $secretData "username" | default "scientist" | b64enc }}
+  {{- if hasKey $secretData "username" }}
+  username: {{ index $secretData "username" }}
+  {{- else }}
+  username: {{ "scientist" | b64enc }}
+  {{- end }}
   {{- $secretPassword := (get $secretData "password") | default (randAlphaNum 16 | b64enc) }}
   password: {{ $secretPassword | quote }}

--- a/k8s/charts/keycloak/templates/secret-user-steward.yaml
+++ b/k8s/charts/keycloak/templates/secret-user-steward.yaml
@@ -7,6 +7,10 @@ data:
   {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "keycloak-secret-user-steward") | default dict }}
   {{- $secretData := (get $secretObj "data") | default dict }}
   # set $keycloakPassword to existing secret data or generate a random one when not exists
-  username: {{ get $secretData "username" | default "steward" | b64enc }}
+  {{- if hasKey $secretData "username" }}
+  username: {{ index $secretData "username" }}
+  {{- else }}
+  username: {{ "steward" | b64enc }}
+  {{- end }}
   {{- $secretPassword := (get $secretData "password") | default (randAlphaNum 16 | b64enc) }}
   password: {{ $secretPassword | quote }}

--- a/k8s/charts/keycloak/templates/secret.yaml
+++ b/k8s/charts/keycloak/templates/secret.yaml
@@ -7,6 +7,14 @@ data:
   {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace "keycloak-secret") | default dict }}
   {{- $secretData := (get $secretObj "data") | default dict }}
   # Admin username for Keycloak 22+
-  admin-username: {{ get $secretData "admin-username" | default "admin" | b64enc }}
+  {{- if hasKey $secretData "admin-username" }}
+  admin-username: {{ index $secretData "admin-username" }}
+  {{- else }}
+  admin-username: {{ "admin" | b64enc }}
+  {{- end }}
   # Admin password - use existing secret data or generate a random one when not exists
-  admin-password: {{ (get $secretData "password") | default (randAlphaNum 16) | b64enc }}
+  {{- if hasKey $secretData "password" }}
+  admin-password: {{ index $secretData "password" }}
+  {{- else }}
+  admin-password: {{ randAlphaNum 16 | b64enc }}
+  {{- end }}


### PR DESCRIPTION
## Problem

When upgrading an existing Keycloak deployment (rather than deploying fresh), Helm was re-applying `b64enc` to values that were already base64-encoded in the existing Secret. This caused authentication failures because the stored credentials became double-encoded.

For example, with the previous logic:
```yaml
admin-username: {{ get $secretData "admin-username" | default "admin" | b64enc }}
```
If `admin-username` already existed in the secret as `YWRtaW4=` (base64 of `admin`), Helm would encode it again, producing a corrupted value.

## Solution

Check whether each key exists in the existing Secret using `hasKey`, and if so reuse its value directly without re-encoding. Only apply `b64enc` when creating new values:

```yaml
{{- if hasKey $secretData "admin-username" }}
admin-username: {{ index $secretData "admin-username" }}
{{- else }}
admin-username: {{ "admin" | b64enc }}
{{- end }}
```

## Files Changed

- `k8s/charts/keycloak/templates/secret.yaml` — admin-username and admin-password fields
- `k8s/charts/keycloak/templates/postgresql-secret.yaml` — database password field
- `k8s/charts/keycloak/templates/secret-user-admin.yaml` — admin user secret
- `k8s/charts/keycloak/templates/secret-user-data.yaml` — data user secret
- `k8s/charts/keycloak/templates/secret-user-steward.yaml` — steward user secret