### PR TITLE
fix(keycloak): tighten service selector and add health probes

### DIFF
--- a/k8s/charts/keycloak/templates/service.yaml
+++ b/k8s/charts/keycloak/templates/service.yaml
@@ -11,4 +11,6 @@ spec:
       targetPort: {{ .Values.service.externalPort }}
       protocol: TCP
       name: {{ .Values.service.name }}
-  selector: {{ include "keycloak.selectorLabels" . | nindent 4 }}
+  selector:
+    {{- include "keycloak.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: keycloak

--- a/k8s/charts/keycloak/templates/statefulset.yaml
+++ b/k8s/charts/keycloak/templates/statefulset.yaml
@@ -18,6 +18,7 @@ spec:
       {{- end }}
       labels:
         {{- include "keycloak.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: keycloak
     spec:
       securityContext:
         runAsUser: 1000
@@ -81,6 +82,22 @@ spec:
               value: edge
             - name: KC_HOSTNAME_STRICT
               value: "false"
+          readinessProbe:
+            httpGet:
+              path: /{{ .Release.Namespace }}/auth/health/ready
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /{{ .Release.Namespace }}/auth/health/live
+              port: 8080
+            initialDelaySeconds: 90
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
           envFrom:
             - secretRef:
                 name: keycloak-secret-user-admin


### PR DESCRIPTION
## Problem

Intermittent 503 errors from the Apache reverse proxy were caused by two issues:

1. **Service selector too broad** — the Keycloak `Service` selected any pod with `app.kubernetes.io/name=keycloak` and `app.kubernetes.io/instance=<release>`. The PostgreSQL pod shares both labels, so Kubernetes occasionally routed Keycloak traffic to PostgreSQL, resulting in connection refused → 503.

2. **No health probes** — without readiness/liveness probes, Kubernetes routed traffic to the Keycloak pod during startup and any transient unhealthy window.

## Changes

### `service.yaml`
Added `app.kubernetes.io/component: keycloak` to the Service selector so it only ever targets Keycloak pods.

### `statefulset.yaml`
- Added `app.kubernetes.io/component: keycloak` to pod template labels so pods match the tighter selector.
- Added `readinessProbe` on `/{{ namespace }}/auth/health/ready` (initial delay 60s, period 10s).
- Added `livenessProbe` on `/{{ namespace }}/auth/health/live` (initial delay 90s, period 15s).

## Validation

- Keycloak pod recreated cleanly: `Ready 1/1`, `RestartCount 0`
- `EndpointSlice` for Service `keycloak` now contains **only** the Keycloak pod IP
- External readiness endpoint `/demo/auth/health/ready` returned HTTP 200 on 20/20 consecutive probes
- Reverse-proxy logs show no new `AH00957`/`AH01114` backend connection errors after the fix