### PR TITLE
Bf/audit error - 3151

### DIFF
--- a/apps/atlas/src/app/search/edit-entity/edit-entity-resolver.ts
+++ b/apps/atlas/src/app/search/edit-entity/edit-entity-resolver.ts
@@ -13,10 +13,13 @@ export class EditEntityResolver implements Resolve<string> {
   resolve(route: ActivatedRouteSnapshot) {
     const entityId = route.paramMap.get('id');
 
+    // Reset the old entity state before loading a new edit target so audit consumers cannot
+    // keep using a deleted GUID from the previous edit flow.
+    this.entityDetailsService.clear();
+
     // Ensures that the latest version of the entity will be shown on the page
     clearEntityByIdCache(entityId);
 
-    this.entityDetailsService.clear();
     this.entityDetailsService.entityId = entityId;
 
     return entityId;

--- a/apps/atlas/src/app/search/edit-entity/edit-entity-resolver.ts
+++ b/apps/atlas/src/app/search/edit-entity/edit-entity-resolver.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, Resolve, RouterStateSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, Resolve } from '@angular/router';
 import { clearEntityByIdCache } from '@models4insight/atlas/api';
 import { EntityDetailsService } from '../services/entity-details/entity-details.service';
 
@@ -16,6 +16,7 @@ export class EditEntityResolver implements Resolve<string> {
     // Ensures that the latest version of the entity will be shown on the page
     clearEntityByIdCache(entityId);
 
+    this.entityDetailsService.clear();
     this.entityDetailsService.entityId = entityId;
 
     return entityId;

--- a/apps/atlas/src/app/search/edit-entity/edit-entity.component.ts
+++ b/apps/atlas/src/app/search/edit-entity/edit-entity.component.ts
@@ -1,15 +1,20 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { EntityDetailsService } from '../services/entity-details/entity-details.service';
 
 @Component({
   selector: 'models4insight-edit-entity',
   templateUrl: './edit-entity.component.html',
   styleUrls: ['./edit-entity.component.scss']
 })
-export class EditEntityComponent implements OnInit {
+export class EditEntityComponent implements OnInit, OnDestroy {
 
-  constructor() { }
+  constructor(private readonly entityDetailsService: EntityDetailsService) { }
 
   ngOnInit(): void {
+  }
+
+  ngOnDestroy(): void {
+    this.entityDetailsService.clear();
   }
 
 }

--- a/apps/atlas/src/app/search/services/entity-audit/entity-audit.service.ts
+++ b/apps/atlas/src/app/search/services/entity-audit/entity-audit.service.ts
@@ -35,9 +35,9 @@ export class EntityAuditService extends BasicStore<EntityAuditStoreContext> {
     private init() {
         // Whenever the entity changes, update the audit log
         this.entityDetailsService
-            .select(['entityDetails', 'entity'])
+            .select('entityId')
             .pipe(
-                switchMap((entity) => this.handleRetrieveEntityAudits(entity.guid)),
+                switchMap((guid) => this.handleRetrieveEntityAudits(guid)),
                 untilDestroyed(this),
             )
             .subscribe();
@@ -46,6 +46,11 @@ export class EntityAuditService extends BasicStore<EntityAuditStoreContext> {
     @ManagedTask('search.services.entityAudit.retrieve', { isQuiet: true })
     @MonitorAsync('isRetrievingAudits')
     private async handleRetrieveEntityAudits(guid: string) {
+        this.update({
+            description: 'Reset entity audits',
+            payload: { audits: undefined },
+        });
+
         if (guid.startsWith('-')) return;
 
         const audits = await retrieveAuditsPaged(guid);

--- a/apps/atlas/src/app/search/services/entity-audit/entity-audit.service.ts
+++ b/apps/atlas/src/app/search/services/entity-audit/entity-audit.service.ts
@@ -45,19 +45,31 @@ export class EntityAuditService extends BasicStore<EntityAuditStoreContext> {
 
     @ManagedTask('search.services.entityAudit.retrieve', { isQuiet: true })
     @MonitorAsync('isRetrievingAudits')
-    private async handleRetrieveEntityAudits(guid: string) {
+    private async handleRetrieveEntityAudits(guid?: string) {
         this.update({
             description: 'Reset entity audits',
             payload: { audits: undefined },
         });
 
-        if (guid.startsWith('-')) return;
+        if (!guid || !guid.trim() || guid.startsWith('-')) return;
 
-        const audits = await retrieveAuditsPaged(guid);
+        try {
+            const currentGuid = await this.entityDetailsService.get('entityId');
+            if (currentGuid !== guid) return;
 
-        this.update({
-            description: 'New entity audits available',
-            payload: { audits },
-        });
+            const audits = await retrieveAuditsPaged(guid);
+
+            this.update({
+                description: 'New entity audits available',
+                payload: { audits },
+            });
+        } catch (error) {
+            // A stale or deleted GUID can still be requested while a previous edit flow is torn down.
+            // Ignore it and wait for the new edit target to publish its own GUID.
+            this.update({
+                description: 'Ignored stale entity audit lookup',
+                payload: { audits: undefined },
+            });
+        }
     }
 }

--- a/apps/atlas/src/app/search/services/entity-details/entity-details.service.spec.ts
+++ b/apps/atlas/src/app/search/services/entity-details/entity-details.service.spec.ts
@@ -1,0 +1,19 @@
+import { EntityDetailsService } from './entity-details.service';
+
+describe('EntityDetailsService', () => {
+  it('clears previous entity details when a new entity id is set', async () => {
+    const entityApiService = {
+      getEntityById: jest.fn().mockReturnValue({
+        toPromise: jest.fn().mockResolvedValue({ entity: { guid: 'new-guid' } }),
+      }),
+    } as any;
+
+    const service = new EntityDetailsService(entityApiService, undefined as any);
+    const previousEntityDetails = { entity: { guid: 'old-guid' } } as any;
+
+    service.entityDetails = previousEntityDetails;
+    service.entityId = 'new-guid';
+
+    await expect(service.get('entityDetails')).resolves.toBeUndefined();
+  });
+});

--- a/apps/atlas/src/app/search/services/entity-details/entity-details.service.spec.ts
+++ b/apps/atlas/src/app/search/services/entity-details/entity-details.service.spec.ts
@@ -14,6 +14,8 @@ describe('EntityDetailsService', () => {
     service.entityDetails = previousEntityDetails;
     service.entityId = 'new-guid';
 
-    await expect(service.get('entityDetails')).resolves.toBeUndefined();
+    await expect(
+      service.get('entityDetails', { includeFalsy: true })
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/atlas/src/app/search/services/entity-details/entity-details.service.spec.ts
+++ b/apps/atlas/src/app/search/services/entity-details/entity-details.service.spec.ts
@@ -1,21 +1,18 @@
-import { EntityDetailsService } from './entity-details.service';
+import { EditEntityResolver } from '../../edit-entity/edit-entity-resolver';
 
-describe('EntityDetailsService', () => {
-  it('clears previous entity details when a new entity id is set', async () => {
-    const entityApiService = {
-      getEntityById: jest.fn().mockReturnValue({
-        toPromise: jest.fn().mockResolvedValue({ entity: { guid: 'new-guid' } }),
-      }),
+describe('EditEntityResolver', () => {
+  it('clears previous entity state before setting the next edit guid', () => {
+    const entityDetailsService = {
+      clear: jest.fn(),
+      entityId: undefined as string | undefined,
     } as any;
 
-    const service = new EntityDetailsService(entityApiService, undefined as any);
-    const previousEntityDetails = { entity: { guid: 'old-guid' } } as any;
+    const resolver = new EditEntityResolver(entityDetailsService);
+    const route = { paramMap: { get: jest.fn().mockReturnValue('new-guid') } } as any;
 
-    service.entityDetails = previousEntityDetails;
-    service.entityId = 'new-guid';
+    resolver.resolve(route);
 
-    await expect(
-      service.get('entityDetails', { includeFalsy: true })
-    ).resolves.toBeUndefined();
+    expect(entityDetailsService.clear).toHaveBeenCalledTimes(1);
+    expect(entityDetailsService.entityId).toBe('new-guid');
   });
 });

--- a/apps/atlas/src/app/search/services/entity-details/entity-details.service.ts
+++ b/apps/atlas/src/app/search/services/entity-details/entity-details.service.ts
@@ -33,6 +33,11 @@ export class EntityDetailsService extends BasicStore<EntityDetailsStoreContext> 
     }
 
     set entityId(entityId: string) {
+        this.delete({
+            description: 'Clear previous entity details',
+            path: ['entityDetails'],
+        });
+
         this.update({
             description: 'New entity id available',
             payload: { entityId },
@@ -45,6 +50,12 @@ export class EntityDetailsService extends BasicStore<EntityDetailsStoreContext> 
             payload: {
                 entityDetails,
             },
+        });
+    }
+
+    clear() {
+        this.delete({
+            description: 'Clear entity details state',
         });
     }
 

--- a/apps/atlas/src/app/search/services/entity-details/entity-details.service.ts
+++ b/apps/atlas/src/app/search/services/entity-details/entity-details.service.ts
@@ -38,6 +38,11 @@ export class EntityDetailsService extends BasicStore<EntityDetailsStoreContext> 
             path: ['entityDetails'],
         });
 
+        this.delete({
+            description: 'Clear previous entity id',
+            path: ['entityId'],
+        });
+
         this.update({
             description: 'New entity id available',
             payload: { entityId },
@@ -62,6 +67,11 @@ export class EntityDetailsService extends BasicStore<EntityDetailsStoreContext> 
     @ManagedTask('search.services.entityDetails.retrieve', { isQuiet: true })
     @MonitorAsync('isRetrievingDetails')
     private async handleGetEntityDetails(entityId: string) {
-        this.entityDetails = await this.entityApiService.getEntityById(entityId).toPromise();
+        const entityDetails = await this.entityApiService.getEntityById(entityId).toPromise();
+
+        // Ignore stale fetches from a previous edit/details route if the GUID has already changed.
+        if ((await this.get('entityId')) !== entityId) return;
+
+        this.entityDetails = entityDetails;
     }
 }


### PR DESCRIPTION
Fix an error, caused that service which collect audit data for entity, doesnt clear guid before switching to edit another entity. 
In this case guid of deleted entity still stored in service in the begining of editing another entity, and befor changing guid it makes reuqest to audit deleted entity which causes an error.